### PR TITLE
fix: syntax on firebase module

### DIFF
--- a/docs/tutorials/ssr/README.md
+++ b/docs/tutorials/ssr/README.md
@@ -24,7 +24,7 @@ module.exports = {
     '@nuxtjs/pwa',
     '@nuxtjs/firebase'
   ],
-  firebase {
+  firebase: {
     // ...
     services: {
       auth: {


### PR DESCRIPTION
Missing ":" in the docs for firebase.