### PR TITLE
docs(guide/introduction): fix typo

### DIFF
--- a/docs/guide/introduction/README.md
+++ b/docs/guide/introduction/README.md
@@ -23,4 +23,4 @@ The module adds a plugin to your Nuxt.js application that handles the initializa
 
 ## Disclaimer
 
-This module is meant for easy and quick set-up of Firebase in a Nuxt project. Due to the nature of this module, it is possibly not optimal for websites that need to be super performant and/or SEO friendly, since the module adds the Firebase services to the global scope. If you wan't your website to be more performant, you'd probably be better off by importing the services only in the files where you need them (i.e. by NOT using this module). That being said, the difference might be marginal depending on your project.
+This module is meant for easy and quick set-up of Firebase in a Nuxt project. Due to the nature of this module, it is possibly not optimal for websites that need to be super performant and/or SEO friendly, since the module adds the Firebase services to the global scope. If you want your website to be more performant, you'd probably be better off by importing the services only in the files where you need them (i.e. by NOT using this module). That being said, the difference might be marginal depending on your project.


### PR DESCRIPTION
Git diff is not so obvious for a long single line, therefore I hereby leave a manual diff.

*Before*

```
If you wan't 
```

*After*

```
If you want 
```