### PR TITLE
fix(types): improve typing of locals

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -231,11 +231,12 @@ export type FireAuthServerUser = Omit<
   'disabled' | 'metadata' | 'providerData'
 > &
   Partial<Pick<auth.UserRecord, 'disabled' | 'metadata' | 'providerData'>> & {
-    allClaims: auth.DecodedIdToken
+    allClaims: auth.DecodedIdToken,
+    idToken: string
   }
 
 declare module 'http' {
   interface ServerResponse {
-    locals: { user: FireAuthServerUser }
+    locals: Record<'user', FireAuthServerUser> & Record<string, any>
   }
 }


### PR DESCRIPTION
### Version
@nuxtjs/firebase: 6.1.0
firebase: 7.16.1
nuxt: 2.13.3

### Reproduction Link
<!-- A minimal test case on https://template.nuxtjs.org/ or GitHub repository that can reproduce the bug. -->

### Steps to reproduce


### What is Expected?


### What is actually happening?

this error is occurred.
```
505:18 Interface 'Response<ResBody>' incorrectly extends interface 'ServerResponse'.
  Types of property 'locals' are incompatible.
    Property 'user' is missing in type 'Record<string, any>' but required in type '{ user: FireAuthServerUser; }'.
    503 | export type Send<ResBody = any, T = Response<ResBody>> = (body?: ResBody) => T;
    504 | 
  > 505 | export interface Response<ResBody = any> extends http.ServerResponse, Express.Response {
        |                  ^
    506 |     /**
    507 |      * Set status `code`.
    508 |      */
```

`locals` has changed from `any` to `Record<string, any>` in this PR.
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46230

`idToken` is added in this PR.
https://github.com/nuxt-community/firebase-module/pull/204