### PR TITLE
Fix found action is always first item in `actions`

### DIFF
--- a/lib/sw-templates/firebase-messaging-sw.js
+++ b/lib/sw-templates/firebase-messaging-sw.js
@@ -22,7 +22,7 @@ const messaging = firebase.messaging()
 self.addEventListener('notificationclick', function(e) {
 
   const actions = <%= serialize(options.actions) %>
-  const action = actions.find(x => x.id === e.action.action)
+  const action = actions.find(x => x.action === e.action)
   const notification = e.notification
 
   if (!action) return


### PR DESCRIPTION
This whoud fix `const action` always refers to first item in `actions` array because:

1. action item does not have `id` property but `action` property, which means the `id `property value is undefined
2. `x,action` value is a string and does not have `action` property too, which means the `action` property value is undefined too
3. comparing undefined with undefined always returns true, then `action` constant will be always the first action in `actions` array