### PR TITLE
Fix found action is always first item in `actions`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -103,7 +103,7 @@ function loadMessaging (options) {
   }
 
   addServiceWorker.call(this, options, 'firebase-messaging-sw.js', {
-    actions: options.actions
+    actions: messaging.actions
   })
 }
 

--- a/lib/sw-templates/firebase-messaging-sw.js
+++ b/lib/sw-templates/firebase-messaging-sw.js
@@ -22,7 +22,7 @@ const messaging = firebase.messaging()
 self.addEventListener('notificationclick', function(e) {
 
   const actions = <%= serialize(options.actions) %>
-  const action = actions.find(x => x.id === e.action.action)
+  const action = actions.find(x => x.action === e.action)
   const notification = e.notification
 
   if (!action) return

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "core-js": "3",
     "cz-conventional-changelog": "latest",
     "eslint": "^7.12.1",
-    "firebase": "^8.0.0",
+    "firebase": "^8.0.1",
     "husky": "^4.3.0",
     "jest": "^26.6.3",
     "nuxt": "^2.14.7",
@@ -54,7 +54,7 @@
     "standard-version": "latest"
   },
   "peerDependencies": {
-    "firebase": "^8.0.0",
+    "firebase": "^8.0.1",
     "nuxt": "^2.14.7"
   },
   "publishConfig": {


### PR DESCRIPTION
This whoud fix `const action` always refers to first item in `actions` array because:

1. `actions` item does not have `id` property but `action`, which means the `id` property value is undefined
2. `x,action` value is a string and does not have `action` property too, which means the `action` property value is undefined too
3. comparing undefined with undefined always returns true, then `action` constant will be always the first action in `actions` array