### PR TITLE
vague error message when required key is missing

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -288,8 +288,9 @@ function validateConfigKeys (options, currentEnv) {
 
   // If one of the required keys is missing, throw an error:
   if (requiredKeys.some(k => !configKeys.includes(k))) {
+    let missingKey = requiredKeys[requiredKeys.findIndex(k => !configKeys.includes(k))];
     return logger.error(
-      `Missing or incomplete config for current environment '${currentEnv}'!`
+      `Missing or incomplete config for current environment '${currentEnv}': key '${missingKey}' is required!`
     )
   }
 


### PR DESCRIPTION
If the config doesn't include one of the required keys, you get an error message as follows: 

`ERROR  Missing or incomplete config for current environment 'development'`

This update improves the error message to include the missing key in the error so the user can address it easily without having to go look into this source code. 

The new error message is as following (when databaseURL is not included in the config): 

`ERROR  Missing or incomplete config for current environment 'development': key 'databaseURL' is required! `