### PR TITLE
Correctly register idTokenChanged callback

### DIFF
--- a/lib/plugins/services/auth.js
+++ b/lib/plugins/services/auth.js
@@ -59,9 +59,9 @@ export default async function (session, firebase, ctx, inject) {
       }
     },
     subscribe() {
-
+      const promises = []
       <% if (hasOnAuthStateChanged && !this.unsubscribeAuthStateListener) { %>
-      return new Promise(resolve => {
+      promises.push(new Promise(resolve => {
         this.unsubscribeAuthStateListener = authService.onAuthStateChanged(async authUser => {
           const claims = authUser ? (await authUser.getIdTokenResult(true)).claims : null
 
@@ -75,11 +75,11 @@ export default async function (session, firebase, ctx, inject) {
 
           resolve()
         })
-      })
+      }))
       <% } %>
 
       <% if (hasIdTokenChanged && !this.unsubscribeIdTokenListener) { %>
-      return new Promise(resolve => {
+      promises.push(new Promise(resolve => {
         this.unsubscribeIdTokenListener = authService.onIdTokenChanged(async authUser => {
           const claims = authUser ? (await authUser.getIdTokenResult(true)).claims : null
 
@@ -93,8 +93,9 @@ export default async function (session, firebase, ctx, inject) {
 
           resolve()
         })
-      })
+      }))
       <% } %>
+      return Promise.all(promises)
     }
   }
   inject('fireAuthStore', fireAuthStore)


### PR DESCRIPTION
Hi there,

It looks like the callback for idTokenChanged was naively introduced in the module in this commit https://github.com/nuxt-community/firebase-module/commit/fcf08463621b36e597dc31d9c542c46632a5beb9#diff-3d37c994b7571c62b0cfb339a4994a7ee10e263b6c6216a3d7b0b19516f52b1d

If both authStateChanged and idTokenChanged callbacks are used, the first return prevents the second callback to be registered so the Firebase update is never propagated.

With this PR, this problem should be fixed. Feel free to ask me to update it if necessarily.