### PR TITLE
docs: add firebase version to getting started

### DIFF
--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -13,14 +13,14 @@ Make sure you are using the newest version of Nuxt and have Firebase installed i
   <code-block label="Yarn" active>
 
 ```bash
-yarn add firebase
+yarn add firebase@8
 ```
 
   </code-block>
   <code-block label="NPM">
 
 ```bash
-npm install firebase
+npm install firebase@8
 ```
 
   </code-block>

--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -13,14 +13,14 @@ Make sure you are using the newest version of Nuxt and have Firebase installed i
   <code-block label="Yarn" active>
 
 ```bash
-yarn add firebase@8
+yarn add firebase@^8
 ```
 
   </code-block>
   <code-block label="NPM">
 
 ```bash
-npm install firebase@8
+npm install firebase@^8
 ```
 
   </code-block>


### PR DESCRIPTION
A quick update to the getting started instructions to enforce firebase version 8, this tripped me up a couple of minutes ago when getting started for the first time.