### PR TITLE
Import firebase type declarations from firebase/compat

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ import { NuxtAppOptions, Configuration } from '@nuxt/types'
 import { NuxtConfiguration } from '@nuxt/vue-app'
 import { ServiceAccount } from 'firebase-admin'
 
-import firebase from 'firebase'
+import firebase from 'firebase/compat'
 import { auth } from 'firebase-admin'
 
 /***********************************


### PR DESCRIPTION
Type declarations are broken as types can not be inferred when working with firebase v9.
I've adjusted `index.d.ts` to import the types from `firebase/compat` instead of just `firebase` (deprecated).

This restores type inference when working with the module.

Fixes #601 