### PR TITLE
feat: add support for App Check

### DIFF
--- a/docs/content/guide/options.md
+++ b/docs/content/guide/options.md
@@ -51,6 +51,7 @@ services: {
   database: true,
   messaging: true,
   performance: true,
+  appCheck: true,
   analytics: true,
   remoteConfig: true
 }

--- a/docs/content/service-options/app-check.md
+++ b/docs/content/service-options/app-check.md
@@ -1,0 +1,21 @@
+---
+title: app-check
+description: ''
+position: 13
+category: Service Options
+---
+
+<alert>
+Client-only - make sure to wrap universal code in <code>if (process.client) {}</code>.
+</alert>
+
+Initializes **Firebase App Check** and makes it available via `$fire.appCheck` and `$fireModule.appCheck`.
+
+- Type: `Boolean` or `Object`
+- Default: `false`
+
+```js[nuxt.config.js]
+appCheck: {
+  debugToken: false, // default
+}
+```

--- a/lib/plugins/services/appCheck.js
+++ b/lib/plugins/services/appCheck.js
@@ -1,0 +1,20 @@
+<% const { serviceMapping, serviceOptions, writeImportStatement, writeInjections } = options %>
+
+export default async function (session) {
+  // Can only be initiated on client side
+  if (!process.client) { 
+    return
+  }
+
+  <% if (!serviceOptions.static) { %>    
+  <%= writeImportStatement(options) %>
+  <% } %>
+  
+  <% /* Uses debug config, if debug token option is set. */ %>
+  <% if (!serviceOptions.debugToken) { %>
+    self.FIREBASE_APPCHECK_DEBUG_TOKEN = <%= serviceOptions.debugToken %>
+  <% } %>
+  const appCheckService = session.<%= serviceMapping.id %>()
+
+  return appCheckService
+}

--- a/lib/plugins/services/appCheck.js
+++ b/lib/plugins/services/appCheck.js
@@ -11,7 +11,7 @@ export default async function (session) {
   <% } %>
   
   <% /* Uses debug config, if debug token option is set. */ %>
-  <% if (!serviceOptions.debugToken) { %>
+  <% if (serviceOptions.debugToken) { %>
     self.FIREBASE_APPCHECK_DEBUG_TOKEN = <%= serviceOptions.debugToken %>
   <% } %>
   const appCheckService = session.<%= serviceMapping.id %>()

--- a/lib/utils/template-utils.js
+++ b/lib/utils/template-utils.js
@@ -12,6 +12,11 @@ const serviceMappings = {
     importName: 'app',
     clientOnly: false,
   },
+  appCheck: {
+    id: 'appCheck',
+    importName: 'appCheck',
+    clientOnly: true,
+  },
   auth: {
     id: 'auth',
     importName: 'auth',

--- a/lib/utils/template-utils.js
+++ b/lib/utils/template-utils.js
@@ -14,7 +14,7 @@ const serviceMappings = {
   },
   appCheck: {
     id: 'appCheck',
-    importName: 'appCheck',
+    importName: 'app-check',
     clientOnly: true,
   },
   auth: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,6 +108,10 @@ export interface MessagingServiceConfig extends ServiceConfig {
 
 export interface PerformanceServiceConfig extends ServiceConfig {}
 
+export interface AppCheckServiceConfig extends ServiceConfig {
+  debugToken?: string
+}
+
 export interface AnalyticsServiceConfig extends ServiceConfig {
   collectionEnabled?: boolean
 }
@@ -136,6 +140,7 @@ export interface FirebaseModuleConfiguration {
     database?: boolean | DatabaseServiceConfig
     messaging?: boolean | MessagingServiceConfig
     performance?: boolean | PerformanceServiceConfig
+    appCheck?: boolean | AppCheckServiceConfig
     analytics?: boolean | AnalyticsServiceConfig
     remoteConfig?: boolean | RemoteConfigServiceConfig
   }
@@ -167,6 +172,7 @@ interface NuxtFireInstance {
   messagingReady: ReadyFunction
   performance: firebase.performance.Performance
   performanceReady: ReadyFunction
+  appCheck: firebase.appCheck.AppCheck
   analytics: firebase.analytics.Analytics
   analyticsReady: ReadyFunction
   remoteConfig: firebase.remoteConfig.RemoteConfig

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,7 +109,7 @@ export interface MessagingServiceConfig extends ServiceConfig {
 export interface PerformanceServiceConfig extends ServiceConfig {}
 
 export interface AppCheckServiceConfig extends ServiceConfig {
-  debugToken?: string
+  debugToken?: string | boolean
 }
 
 export interface AnalyticsServiceConfig extends ServiceConfig {


### PR DESCRIPTION
### Support for App Check
Adds support for [Firebase App Check](https://firebase.google.com/docs/app-check).

**Note: This will currently work only on the client side.**

### Initialize:
Enable App Check inside `nuxt.config.js`:
```js
firebase: {
  ...
  services: {
    ...,
    appCheck: true
  }
}
```

**Options:**
```js
{
  // Fill debug token to be used.
  // See more https://firebase.google.com/docs/app-check/web/debug-provider
  debugToken: false // default
}
```

### Usage
When initialized there is possibility to activate App Check by calling 
```js
// App check works currently only on client side.
if (process.client) {
  this.$fire.appCheck.activate('RECAPTCHA V3 SITE KEY')`
}
```

### Relates to
https://github.com/nuxt-community/firebase-module/issues/534

