### PR TITLE
fix: add lazy load to app check and fix collection is not a function

### DIFF
--- a/docs/content/guide/options.md
+++ b/docs/content/guide/options.md
@@ -137,6 +137,7 @@ When set to `true`, all services are NOT loaded until you manually load them whe
 | Performance       | $fire.performanceReady()  |
 | Analytics         | $fire.analyticsReady()    |
 | Remote Config     | $fire.remoteConfigReady() |
+| App Check         | $fire.appCheckReady() |
 
 Simply call the `await this.$fire.serviceNameReady()` function before you access `this.$fire.serviceName` and the service gets dynamically loaded only when needed.
 

--- a/lib/plugins/services/appCheck.js
+++ b/lib/plugins/services/appCheck.js
@@ -7,14 +7,10 @@ export default async function (session) {
   }
 
   <% if (!serviceOptions.static) { %>    
-  <%= writeImportStatement(options) %>
+    <%= writeImportStatement(options) %>
   <% } %>
-  
-  <% /* Uses debug config, if debug token option is set. */ %>
-  <% if (serviceOptions.debugToken) { %>
-    self.FIREBASE_APPCHECK_DEBUG_TOKEN = <%= serviceOptions.debugToken %>
-  <% } %>
+    
   const appCheckService = session.<%= serviceMapping.id %>()
-
+  
   return appCheckService
 }

--- a/lib/plugins/services/appCheck.js
+++ b/lib/plugins/services/appCheck.js
@@ -9,6 +9,11 @@ export default async function (session) {
   <% if (!serviceOptions.static) { %>    
     <%= writeImportStatement(options) %>
   <% } %>
+  
+  <% /* Uses debug config, if debug token option is set. */ %>
+  <% if (serviceOptions.debugToken) { %>
+    self.FIREBASE_APPCHECK_DEBUG_TOKEN = <%= serviceOptions.debugToken %>
+  <% } %>
     
   const appCheckService = session.<%= serviceMapping.id %>()
   

--- a/lib/utils/template-utils.js
+++ b/lib/utils/template-utils.js
@@ -12,11 +12,6 @@ const serviceMappings = {
     importName: 'app',
     clientOnly: false,
   },
-  appCheck: {
-    id: 'appCheck',
-    importName: 'app-check',
-    clientOnly: true,
-  },
   auth: {
     id: 'auth',
     importName: 'auth',
@@ -61,6 +56,11 @@ const serviceMappings = {
   remoteConfig: {
     id: 'remoteConfig',
     importName: 'remote-config',
+    clientOnly: true,
+  },
+  appCheck: {
+    id: 'appCheck',
+    importName: 'app-check',
     clientOnly: true,
   },
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -173,6 +173,7 @@ interface NuxtFireInstance {
   performance: firebase.performance.Performance
   performanceReady: ReadyFunction
   appCheck: firebase.appCheck.AppCheck
+  appCheckReady: ReadyFunction
   analytics: firebase.analytics.Analytics
   analyticsReady: ReadyFunction
   remoteConfig: firebase.remoteConfig.RemoteConfig


### PR DESCRIPTION
### Description
- Fixed bug when `$fire.firestore.collection()` was not a function
- Added lazy load to App check library.

### Usage
**Note: Use only on clientside hooks**
For example:
```js
mounted() {
  this.loadAppCheck()
},
methods: {
  async loadAppCheck() {
    await this.$fire.appCheckReady()
    await this.$fire.appCheck.activate('RECAPTCHA V3 KEY')
  }
```
**or**
```js
if (process.client) {
    await this.$fire.appCheckReady()
    await this.$fire.appCheck.activate('RECAPTCHA V3 KEY')
}