### PR TITLE
fix(docs): typo

### DIFF
--- a/packages/docs/content/tutorials/typescript.md
+++ b/packages/docs/content/tutorials/typescript.md
@@ -5,7 +5,7 @@ position: 18
 category: Tutorials
 ---
 
-The module comes with types by providing a decleration file (`index.d.ts`) within the npm package.
+The module comes with types by providing a declaration file (`index.d.ts`) within the npm package.
 
 All you need to do is to include "@nuxtjs/firebase" in your tsconfig.json types like so:
 


### PR DESCRIPTION
Fixes a typo in the documentation page: https://firebase.nuxtjs.org/tutorials/typescript